### PR TITLE
site crashes caused by opening non-existing file

### DIFF
--- a/hosted-content-importer/classes/hci/class.hosted_content_importer.inc.php
+++ b/hosted-content-importer/classes/hci/class.hosted_content_importer.inc.php
@@ -114,10 +114,13 @@ final class hosted_content_importer
 
 	private function _autoload_processors($class_name = '')
 	{
-		$processor = require_once(HCI_PLUGIN_DIR . "/classes/processors/class.{$class_name}.inc.php");
-		if(is_file($processor))
-		{
-			require_once($processor);
-		}
+        if(file_exists(HCI_PLUGIN_DIR . "/classes/processors/class.{$class_name}.inc.php"))
+        {
+            $processor = require_once(HCI_PLUGIN_DIR . "/classes/processors/class.{$class_name}.inc.php");
+            if(is_file($processor))
+            {
+                require_once($processor);
+            }
+        }
 	}
 }


### PR DESCRIPTION
HCI tried to open non-existing file. It crashes and as a consequence the web page does not display additional widgets and panels. In my case it was the WooCommerce class and class.WooCommerce.inc.php file which did not exist.
